### PR TITLE
Update to symfony/http-kernel a ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^8.2",
         "ext-json": "*",
         "jane-php/open-api-runtime": "^7.6.1",
-        "symfony/http-kernel": "^6.0"
+        "symfony/http-kernel": "^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.11",


### PR DESCRIPTION
# Dependency Update

This pull request updates the required version of symfony/http-kernel from ^6.0 to ^7.0, while maintaining compatibility with PHP 8.2+.

## Changes
- Updated symfony/http-kernel to ^7.0 in composer.json

## Why
This update allows using more recent versions of http-kernel while maintaining compatibility with modern PHP versions.